### PR TITLE
Fix incorrect variable name arguments.content

### DIFF
--- a/models/AmazonS3.cfc
+++ b/models/AmazonS3.cfc
@@ -714,7 +714,7 @@ component accessors="true" singleton {
 		};
 
 		if ( arguments.md5 == "auto" ) {
-			headers[ "content-md5" ] = mD5inBase64( arguments.content );
+			headers[ "content-md5" ] = mD5inBase64( arguments.data );
 		} else if ( len( arguments.md5 ) ) {
 			headers[ "content-md5" ] = arguments.md5;
 		}


### PR DESCRIPTION
The argument name in putObject() was incorrect "arguments.content" instead of "arguments.data", this only happens when md5 == "auto" so it probably slipped by for some time.